### PR TITLE
Add github action badge to the readme

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,4 +1,4 @@
-![Build](https://github.com/github/docs/actions/workflows/build.yml/badge.svg?branch=develop)
+![Build](https://github.com/VDP-noclip/noclip/actions/workflows/build.yml/badge.svg?branch=develop)
 
 # noclip
 


### PR DESCRIPTION
Fix the current readme and correctly display the action status that checks the project build