### PR TITLE
Minor change to allplayer prefab: center parent and children

### DIFF
--- a/Assets/Level/Prefabs/Player/AllPlayer.prefab
+++ b/Assets/Level/Prefabs/Player/AllPlayer.prefab
@@ -24,7 +24,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 603454259776399200}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 5.7593217, y: 2.42354, z: -0.5599687}
+  m_LocalPosition: {x: 0, y: 2.42354, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -58,7 +58,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 766645312306153727}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -5.7593217, y: 0.17645979, z: 0.5599687}
+  m_LocalPosition: {x: 0, y: 0.17645979, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -590,7 +590,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8843948785228655744}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -5.7593217, y: -0.42354012, z: 0.5599687}
+  m_LocalPosition: {x: 0, y: -0.42354012, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -646,6 +646,7 @@ MonoBehaviour:
   _maxSlopeAngle: 0
   _orientation: {fileID: 7238088810028651136}
   _state: 0
+  Grounded: 0
 --- !u!114 &2967285917822573420
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
I noticed that the parent of the allPlayer prefab had different coordinates than the children. It is clearer if they all share the same x and z coordinates in my opinion.