### PR TITLE
add boolean for noclip mode recognition

### DIFF
--- a/Assets/Code/Scripts/NoclipRealityManagement/NoclipManager.cs
+++ b/Assets/Code/Scripts/NoclipRealityManagement/NoclipManager.cs
@@ -13,7 +13,7 @@ public class NoclipManager : MonoBehaviour
     private List<BaseNoclipObjectController> _noclipObjControllers;
     private CameraManager _cameraManager;
 
-    private bool _noclipEnabled;
+    private bool _noclipEnabled;   
     private bool _playerCanEnableNoclip;
     private bool _playerCanDisableNoclip;
 
@@ -58,8 +58,8 @@ public class NoclipManager : MonoBehaviour
     private void EnableNoclip()
     {
         _noclipObjControllers.ForEach(obj => obj.ActivateNoclip());
-        _cameraManager.SwitchCamera();
         _noclipEnabled = true;
+        _cameraManager.SwitchCamera();
     }
 
     /// <summary>
@@ -68,8 +68,8 @@ public class NoclipManager : MonoBehaviour
     private void DisableNoclip()
     {
         _noclipObjControllers.ForEach(obj => obj.DisableNoclip());
-        _cameraManager.SwitchCamera();
         _noclipEnabled = false;
+        _cameraManager.SwitchCamera();
     }
 
     /// <summary>

--- a/Assets/Code/Scripts/NoclipRealityManagement/NoclipMovement.cs
+++ b/Assets/Code/Scripts/NoclipRealityManagement/NoclipMovement.cs
@@ -40,10 +40,7 @@ public class NoclipMovement : MonoBehaviour
     private CameraManager _cameraManager;
     private Transform _noclipCamera;
     private NoclipManager _noclipManager;
-    
-    // It's true if is the noclipPlayer, it's false if is the reality body
-    private bool _currentPlayer = false;
-    
+
     // These positions depends o the level 
     private Vector3 _initRotation;
     private Vector3 _initPosition;
@@ -63,7 +60,7 @@ public class NoclipMovement : MonoBehaviour
         if (!_active)
             return;
         
-        if (_enableMovement && _currentPlayer)
+        if (_enableMovement && _noclipManager.IsNoclipEnabled())
         {
             Vector3 deltaPosition = Vector3.zero;
             float currentSpeed = _movementSpeed;
@@ -96,7 +93,7 @@ public class NoclipMovement : MonoBehaviour
 
     private void OnTriggerEnter(Collider other)
     {
-        if (other.CompareTag("RealityPlayer") && _currentPlayer)
+        if (other.CompareTag("RealityPlayer") && _noclipManager.IsNoclipEnabled())
         {
             _noclipManager.SetPlayerCanDisableNoclip(true);
         }
@@ -108,11 +105,6 @@ public class NoclipMovement : MonoBehaviour
         {
             _noclipManager.SetPlayerCanDisableNoclip(false);
         }
-    }
-
-    public void ActivatePlayer(bool active)
-    {
-        _currentPlayer = active;
     }
 
     public void SetPositionAndRotation(Vector3 position, Quaternion cameraOrientation)

--- a/Assets/Code/Scripts/NoclipRealityManagement/RealityMovement.cs
+++ b/Assets/Code/Scripts/NoclipRealityManagement/RealityMovement.cs
@@ -61,6 +61,7 @@ public class RealityMovement : MonoBehaviour
 
     private Transform _transform;
     private Rigidbody _rigidbody;      // set the rigidbody
+    private NoclipManager _noclipManager;
 
     // It's true if is the realbody, it's false if is the noclip body
     private bool _currentPlayerBody  = true;
@@ -76,6 +77,7 @@ public class RealityMovement : MonoBehaviour
         _rigidbody = GetComponent<Rigidbody>();
         Physics.gravity *= _gravityMultiplier;   // Change the gravity
         _transform = GetComponent<Transform>();
+        _noclipManager = FindObjectOfType<NoclipManager>();
     }
 
     // Start is called before the first frame update
@@ -92,7 +94,7 @@ public class RealityMovement : MonoBehaviour
     // Update is called once per frame
     private void Update()
     {
-        if (_currentPlayerBody)
+        if (!_noclipManager.IsNoclipEnabled())
         {
             //Alternative 1
             //_grounded = Physics.Raycast(_transform.position,  Vector3.down, _playerHeight * 0.5f + 0.3f, _ground);
@@ -121,11 +123,6 @@ public class RealityMovement : MonoBehaviour
     public void ResetSpeedOnRespawn()
     {
         _rigidbody.velocity = Vector3.zero;
-    }
-    
-    public void ActivatePlayer(bool active)
-    {
-        _currentPlayerBody = active;
     }
 
     // 

--- a/Assets/Code/Scripts/PlayerManagement/CameraManager.cs
+++ b/Assets/Code/Scripts/PlayerManagement/CameraManager.cs
@@ -8,7 +8,6 @@ public class CameraManager : MonoBehaviour
     
     [SerializeField] private GameObject _realPlayer;
     [SerializeField] private GameObject _realPlayerCamera;
-    private RealityMovement _realPlayerMovement;  // this isn't used
     private MouseLook _realMouseLook;
     
     [SerializeField] private GameObject _noclipCamera;
@@ -18,7 +17,6 @@ public class CameraManager : MonoBehaviour
     private NoclipManager _noclipManager;
     private void Awake()
     {
-        _realPlayerMovement = _realPlayer.GetComponent<RealityMovement>();
         _noclipMovement = _noclipCamera.GetComponent<NoclipMovement>();
 
         _realMouseLook = _realPlayerCamera.GetComponent<MouseLook>();

--- a/Assets/Code/Scripts/PlayerManagement/CameraManager.cs
+++ b/Assets/Code/Scripts/PlayerManagement/CameraManager.cs
@@ -8,15 +8,14 @@ public class CameraManager : MonoBehaviour
     
     [SerializeField] private GameObject _realPlayer;
     [SerializeField] private GameObject _realPlayerCamera;
-    private RealityMovement _realPlayerMovement;
+    private RealityMovement _realPlayerMovement;  // this isn't used
     private MouseLook _realMouseLook;
     
     [SerializeField] private GameObject _noclipCamera;
     private NoclipMovement _noclipMovement;
     private MouseLook _noclipMouseLook;
 
-    //Thi boolean is true when the realPlayer is active, so the game is in the reality mode
-    private bool _activeRealPlayer;
+    private NoclipManager _noclipManager;
     private void Awake()
     {
         _realPlayerMovement = _realPlayer.GetComponent<RealityMovement>();
@@ -24,41 +23,39 @@ public class CameraManager : MonoBehaviour
 
         _realMouseLook = _realPlayerCamera.GetComponent<MouseLook>();
         _noclipMouseLook = _noclipCamera.GetComponent<MouseLook>();
+        
+        _noclipManager = FindObjectOfType<NoclipManager>();
 
     }
 
     // Start is called before the first frame update
     void Start()
     {
-        _realPlayerCamera.SetActive(true);
-        _realPlayerMovement.ActivatePlayer(true);
-        _realMouseLook.ActivateMouseLook(true);
+        bool isNoclipEnabled = _noclipManager.IsNoclipEnabled();
         
-        _noclipCamera.SetActive(false);
-        _noclipMovement.ActivatePlayer(false);
-        _noclipMouseLook.ActivateMouseLook(false);
+        _realPlayerCamera.SetActive(!isNoclipEnabled);
+        _realMouseLook.ActivateMouseLook(!isNoclipEnabled);
         
-        _activeRealPlayer = true;
+        _noclipCamera.SetActive(isNoclipEnabled);
+        _noclipMouseLook.ActivateMouseLook(isNoclipEnabled);
     }
     
     public void SwitchCamera()
     {
-        _activeRealPlayer = !_activeRealPlayer;
+        bool isNoclipEnabled = _noclipManager.IsNoclipEnabled();
         
         //Activate/disactivate the realPlayer and his camera
-        _realPlayerCamera.SetActive(_activeRealPlayer);
-        _realPlayerMovement.ActivatePlayer(_activeRealPlayer);
-        _realMouseLook.ActivateMouseLook(_activeRealPlayer);
+        _realPlayerCamera.SetActive(!isNoclipEnabled);
+        _realMouseLook.ActivateMouseLook(!isNoclipEnabled);
         
-        if (!_activeRealPlayer) //When the switch from reality mode to noclip mode happened
+        if (isNoclipEnabled) //When the switch from reality mode to noclip mode happened
         {
             _noclipMovement.SetPositionAndRotation(_realPlayer.transform.position, _realPlayerCamera.transform.rotation); //Set the noclip position in the realBody position
         }
         
         //Activate/disactivate the noclipPlayer and his camera
-        _noclipCamera.SetActive(!_activeRealPlayer);
-        _noclipMovement.ActivatePlayer(!_activeRealPlayer);
-        _noclipMouseLook.ActivateMouseLook(!_activeRealPlayer);
+        _noclipCamera.SetActive(isNoclipEnabled);
+        _noclipMouseLook.ActivateMouseLook(isNoclipEnabled);
 
         
     }


### PR DESCRIPTION
Now the boolean that indicates if the player is in no clip mode is centralized:
- only the noclip manager owns this information
- the reality player and the noclip player should retrive the information from the noclip manager