### PR TITLE
Minor fix: load 0_Main instead of Area_00 in the Menu_0 scene

### DIFF
--- a/Assets/Level/Scenes/Menu_0.unity
+++ b/Assets/Level/Scenes/Menu_0.unity
@@ -5142,7 +5142,7 @@ MonoBehaviour:
   defaultVolume: 1
   confirmationPrompt: {fileID: 2054656209}
   noSavedGameDialog: {fileID: 651551500}
-  _newGameLevel: Area_00
+  _newGameLevel: 0_Main
   resolutionDropdown: {fileID: 1569892673}
 --- !u!4 &771194625
 Transform:

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -26,4 +26,7 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Level/Scenes/Backgrounds/Area_01_Background.unity
     guid: 885efde003b67e5409d190b4337d11c5
+  - enabled: 1
+    path: Assets/Level/Scenes/0_Main.unity
+    guid: 73bbe6744146252438023e65248d6b58
   m_configObjects: {}


### PR DESCRIPTION
The menu was still loading Area_00, but after one of the last refactorings we actually need to load Menu_0.