### PR TITLE
Bugfix: apply "Default" layer since the empty layer is not in the layers list

### DIFF
--- a/Assets/Level/Prefabs/Puzzles/PuzzleComponents/ObjectsHolders/IntangibleNoclipObjectsHolder.prefab
+++ b/Assets/Level/Prefabs/Puzzles/PuzzleComponents/ObjectsHolders/IntangibleNoclipObjectsHolder.prefab
@@ -45,4 +45,4 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _tagToApply: NoclipObject
-  _layerToApply: 
+  _layerToApply: Default


### PR DESCRIPTION
A really minor bugfix. The game works even without this fix, apart from the fact that the IntangibleObjectsHolder does not enforce the tags to its children.