### PR TITLE
Improve game manager and puzzle manager code

### DIFF
--- a/Assets/Code/Scripts/LevelManagement/GameManager.cs
+++ b/Assets/Code/Scripts/LevelManagement/GameManager.cs
@@ -12,6 +12,7 @@ public class GameManager : MonoBehaviour
     [SerializeField] private float _gravity;
 
     private int _currentGameAreaIndex;
+    private int _finalGameAreaIndex;
     [SerializeField] private GameState _gameState = GameState.InitializeGame;
 
     //enum game states
@@ -19,20 +20,34 @@ public class GameManager : MonoBehaviour
     {
         InitializeGame,
         AreaFinished,
-        NewArea
+        NewArea,
+        GameCompleted
     }
-
-    // Update is called once per frame
+    
+    private void Awake()
+    {
+        SceneManager.LoadScene(_gameAreas[_currentGameAreaIndex], LoadSceneMode.Additive);
+        _finalGameAreaIndex = _gameAreas.Count - 1;
+    }
+    
     private void Update()
     {
-        //if area is finished load next area
+        //if area is finished load next area, complete the game if it is the last one
         if (_gameState == GameState.AreaFinished)
         {
-            _currentGameAreaIndex += 1;
-            CloseAllScenes();
-            DestroyOtherGameObjects();
-            SceneManager.LoadScene(_gameAreas[_currentGameAreaIndex], LoadSceneMode.Additive);
-            _gameState = GameState.NewArea;
+            if (_currentGameAreaIndex == _finalGameAreaIndex)
+            {
+                _gameState = GameState.GameCompleted;
+                Debug.Log("Congratulations, you have completed the game!");
+            }
+            else
+            {
+                _gameState = GameState.NewArea;
+                CloseAllScenes();
+                DestroyOtherGameObjects();
+                _currentGameAreaIndex += 1;
+                SceneManager.LoadScene(_gameAreas[_currentGameAreaIndex], LoadSceneMode.Additive);
+            }
         }
     }
 

--- a/Assets/Code/Scripts/Utils/PuzzleManager.cs
+++ b/Assets/Code/Scripts/Utils/PuzzleManager.cs
@@ -8,21 +8,41 @@ public class PuzzleManager : MonoBehaviour
     [SerializeField] private GameObject[] _puzzlePrefabs;
 
     private int _currentPuzzleIndex;
+    private int _finalPuzzleIndex;
 
     private GameObject _gameManager;
     private Vector3 _puzzlePosition;
     
     private void Awake()
     {
-        LoadNextPuzzle();
+        LoadCurrentPuzzle();
+        _finalPuzzleIndex = _puzzlePrefabs.Length - 1;
     }
-
+    
+    /// <summary>
+    /// Call this function when the puzzle is finished and you need to move to the next one. If the current puzzle is
+    /// the last one, set the game state to AreaFinished
+    /// </summary>
     public void LoadNextPuzzle()
     {
-        //NOTE puzzles don't snap perfectly between anchors probably because of rotations
-        try{
-            GameObject newPuzzle = Instantiate(_puzzlePrefabs[_currentPuzzleIndex]);
+        if (_currentPuzzleIndex != _finalPuzzleIndex)
+        {
             _currentPuzzleIndex += 1;
+            LoadCurrentPuzzle();
+            GameObject.Find("RealityPlayer").GetComponent<NoclipManager>().FindNoClipObjControllers();
+        }
+        else
+        {
+            Debug.Log("No more puzzles to load. Area finished!");
+            GameObject.Find("GameManager").GetComponent<GameManager>().SetAreaFinished();
+        }
+    }
+
+    private void LoadCurrentPuzzle()
+    {
+            //NOTE: puzzles don't snap perfectly between anchors probably because of rotations
+            GameObject newPuzzle = Instantiate(_puzzlePrefabs[_currentPuzzleIndex]);
+            
             //rotate newPuzzle.transform.Find("BeginAnchor") to zero
             //newPuzzle.transform.Find("BeginAnchor").transform.rotation = Quaternion.Euler(0, 0, 0);
             //find begin anchor
@@ -55,15 +75,5 @@ public class PuzzleManager : MonoBehaviour
             pole.transform.localScale = new Vector3(0.1f, 0.1f, 0.1f);
             pole.GetComponent<Renderer>().material.color = Color.green;
             */
-            
-            if (_currentPuzzleIndex > 1)
-                GameObject.Find("RealityPlayer").GetComponent<NoclipManager>().FindNoClipObjControllers();
-        }
-        catch (IndexOutOfRangeException){
-            Debug.Log("No more puzzles to load");
-            GameObject.Find("GameManager").GetComponent<GameManager>().SetAreaFinished();
-            return;
-            //GameObject.Find("GameManager").GetComponent<GameManager>().CloseAllScenes();
-        }
     }
 }

--- a/Assets/Level/Prefabs/Puzzles/Puzzle_12.prefab
+++ b/Assets/Level/Prefabs/Puzzles/Puzzle_12.prefab
@@ -2351,7 +2351,7 @@ PrefabInstance:
     - target: {fileID: 778394975768400163, guid: 28076ca917b19704e8a15d38abd92651,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 112.06
+      value: 114.4
       objectReference: {fileID: 0}
     - target: {fileID: 778394975768400163, guid: 28076ca917b19704e8a15d38abd92651,
         type: 3}

--- a/Assets/Level/Prefabs/Puzzles/Puzzle_13.prefab
+++ b/Assets/Level/Prefabs/Puzzles/Puzzle_13.prefab
@@ -30,7 +30,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8313678432249329610}
   m_LocalRotation: {x: -0, y: -0.40056583, z: -0, w: 0.916268}
-  m_LocalPosition: {x: 25.29, y: -5.8, z: 193.53}
+  m_LocalPosition: {x: 25.29, y: -5.8, z: 197}
   m_LocalScale: {x: 3.2737226, y: 1, z: 1.2687876}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -870,7 +870,7 @@ PrefabInstance:
     - target: {fileID: 778394975768400163, guid: 28076ca917b19704e8a15d38abd92651,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 157.55
+      value: 164.8
       objectReference: {fileID: 0}
     - target: {fileID: 778394975768400163, guid: 28076ca917b19704e8a15d38abd92651,
         type: 3}

--- a/Assets/Level/Scenes/0_Main.unity
+++ b/Assets/Level/Scenes/0_Main.unity
@@ -133,7 +133,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1092676115}
   - component: {fileID: 1092676117}
-  - component: {fileID: 1092676116}
   m_Layer: 0
   m_Name: GameManager
   m_TagString: Untagged
@@ -156,20 +155,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1092676116
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1092676114}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e54ebd674fc84fb9934c494ec8ab58ad, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _scenesToLoad:
-  - Area_00
 --- !u!114 &1092676117
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -182,10 +167,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0563da06eccd61945948b3d2649353fc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _gameState: INITIALIZE_GAME
   _gameAreas:
   - Area_00
   - Area_01
-  - Area_00
-  _debugChannel: unloadScenes
   _gravity: 0
+  _gameState: 2


### PR DESCRIPTION
### Game Manager
@TizioMaurizio as discussed, I removed the additive scene loader component from the game manager and I rely uniquely on the list `_gameAreas`. 

Moreover, I have added the `GameCompleted`  state (I think you already added it, and I removed it by mistake). We are in this state when we finish the last area in `_gameAreas`.

### Puzzle Manager
Here I made a minor improvement. Instead of using an exception, I check when we reach the final puzzle index and act accordingly. I think the code is easier to read and to maintain in case we find bugs.