### PR TITLE
Fix starting orientations of the cameras

### DIFF
--- a/Assets/Code/Scripts/PlayerManagement/MouseLook.cs
+++ b/Assets/Code/Scripts/PlayerManagement/MouseLook.cs
@@ -46,7 +46,6 @@ public class MouseLook : MonoBehaviour
     {
         Cursor.lockState = CursorLockMode.Locked;
         Cursor.visible = false;
-        
     }
     
     void Update()


### PR DESCRIPTION
I tried some stuff but it's better to leave it, someone that knows better about the orientation should look into it and fix it.
Eventually it should be possible to easily change the player initial spawning orientation from the editor and when switching to noclip the camera should keep looking where it was looking before.