### PR TITLE
update unity to 2021.3.14f1

### DIFF
--- a/Assets/Code/Scripts/PlayerManagement/MouseLook.cs
+++ b/Assets/Code/Scripts/PlayerManagement/MouseLook.cs
@@ -59,8 +59,14 @@ public class MouseLook : MonoBehaviour
         if (_activeCurrently)
         {
             // get mouse input and proportionally modify the sensitivity
-            float mouseX = Input.GetAxisRaw("Mouse X") * _xSensitivity * _sensitivity; //NB: here X refers to the axis of the screen
-            float mouseY = Input.GetAxisRaw("Mouse Y") * _ySensitivity * _sensitivity; //NB: here Y refers to the axis of the screen
+            float mouseX = 0;
+            float mouseY = 0;
+            //if time is flowing
+            if(Time.deltaTime > 0)
+            {
+                mouseX = Input.GetAxisRaw("Mouse X") * _xSensitivity * _sensitivity; //NB: here X refers to the axis of the screen
+                mouseY = Input.GetAxisRaw("Mouse Y") * _ySensitivity * _sensitivity; //NB: here Y refers to the axis of the screen
+            }
         
             // calculate the rotation in both axis
             _yRotation += mouseX; // the x screen axis corresponds to a rotation on the y axis of the camera 

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -7,7 +7,7 @@
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.postprocessing": "3.2.2",
     "com.unity.probuilder": "5.0.6",
-    "com.unity.render-pipelines.universal": "12.1.7",
+    "com.unity.render-pipelines.universal": "12.1.8",
     "com.unity.test-framework": "1.3.0",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.6.4",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -94,7 +94,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.render-pipelines.core": {
-      "version": "12.1.7",
+      "version": "12.1.8",
       "depth": 1,
       "source": "builtin",
       "dependencies": {
@@ -104,14 +104,14 @@
       }
     },
     "com.unity.render-pipelines.universal": {
-      "version": "12.1.7",
+      "version": "12.1.8",
       "depth": 0,
       "source": "builtin",
       "dependencies": {
         "com.unity.mathematics": "1.2.1",
         "com.unity.burst": "1.7.3",
-        "com.unity.render-pipelines.core": "12.1.7",
-        "com.unity.shadergraph": "12.1.7"
+        "com.unity.render-pipelines.core": "12.1.8",
+        "com.unity.shadergraph": "12.1.8"
       }
     },
     "com.unity.searcher": {
@@ -122,7 +122,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.services.core": {
-      "version": "1.4.2",
+      "version": "1.6.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -140,11 +140,11 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.shadergraph": {
-      "version": "12.1.7",
+      "version": "12.1.8",
       "depth": 1,
       "source": "builtin",
       "dependencies": {
-        "com.unity.render-pipelines.core": "12.1.7",
+        "com.unity.render-pipelines.core": "12.1.8",
         "com.unity.searcher": "4.9.1"
       }
     },

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2021.3.11f1
-m_EditorVersionWithRevision: 2021.3.11f1 (0a5ca18544bf)
+m_EditorVersion: 2021.3.14f1
+m_EditorVersionWithRevision: 2021.3.14f1 (eee1884e7226)


### PR DESCRIPTION
Unity updated to 2021.3.14f1 to fix the crash when working with prefabs, the only bug to report is that the view keeps moving after pause, everything else works both in editor and after build.