### PR TITLE
Set the same camera orientation when switching from noclip mode to reality mode

### DIFF
--- a/Assets/Code/Scripts/PlayerManagement/CameraManager.cs
+++ b/Assets/Code/Scripts/PlayerManagement/CameraManager.cs
@@ -49,6 +49,11 @@ public class CameraManager : MonoBehaviour
         if (isNoclipEnabled) //When the switch from reality mode to noclip mode happened
         {
             _noclipMovement.SetPositionAndRotation(_realPlayer.transform.position, _realPlayerCamera.transform.rotation); //Set the noclip position in the realBody position
+            _noclipMouseLook.CopyRotationCoordinates(_realMouseLook);
+        }
+        else
+        {
+            _realMouseLook.CopyRotationCoordinates(_noclipMouseLook);
         }
         
         //Activate/disactivate the noclipPlayer and his camera

--- a/Assets/Code/Scripts/PlayerManagement/MouseLook.cs
+++ b/Assets/Code/Scripts/PlayerManagement/MouseLook.cs
@@ -73,9 +73,12 @@ public class MouseLook : MonoBehaviour
             _xRotation -= mouseY; // the y screen axis corresponds to a rotation on the x axis of the camera 
             _xRotation = Mathf.Clamp(_xRotation, -90f, 90f);    // Clamping allows to block the rotation
             
+            // TODO check the right name for the orientation: in this way are a little confusing terms
+            
+            // IMPORTANT: Don't change the order of the two following lines: if _orientation and _transform are the same gameobject it doesn't work due to value override.
             _orientation.rotation = Quaternion.Euler(0, _yRotation, 0);  // updates the orientation of the gameobject that has the orientation information of the camera on the y axis
             _transform.rotation = Quaternion.Euler(_xRotation*_invertY, _yRotation, 0);  // updates the camera orientation
-
+            
             // Checks whether there's local information about vertical axis preference and changes it.
             // I don't know the cost of this statement but it definitely doesn't belong here.
             UpdateInvertY();

--- a/Assets/Code/Scripts/PlayerManagement/MouseLook.cs
+++ b/Assets/Code/Scripts/PlayerManagement/MouseLook.cs
@@ -2,10 +2,10 @@ using System;
 using Unity.VisualScripting;
 using UnityEngine;
 
-    /// <summary>
-    /// Everything here is linked to how cursor input is processed and used.
-    /// Rotation, orientation, sensitivity handling and eventual added preferences such as inverted vertical axis.
-    /// </summary>
+/// <summary>
+/// Everything here is linked to how cursor input is processed and used.
+/// Rotation, orientation, sensitivity handling and eventual added preferences such as inverted vertical axis.
+/// </summary>
 public class MouseLook : MonoBehaviour
 {
     [SerializeField]
@@ -73,12 +73,9 @@ public class MouseLook : MonoBehaviour
             _xRotation -= mouseY; // the y screen axis corresponds to a rotation on the x axis of the camera 
             _xRotation = Mathf.Clamp(_xRotation, -90f, 90f);    // Clamping allows to block the rotation
             
-            // TODO check the right name for the orientation: in this way are a little confusing terms
-            
-            // IMPORTANT: Don't change the order of the two following lines: if _orientation and _transform are the same gameobject it doesn't work due to value override.
             _orientation.rotation = Quaternion.Euler(0, _yRotation, 0);  // updates the orientation of the gameobject that has the orientation information of the camera on the y axis
             _transform.rotation = Quaternion.Euler(_xRotation*_invertY, _yRotation, 0);  // updates the camera orientation
-            
+
             // Checks whether there's local information about vertical axis preference and changes it.
             // I don't know the cost of this statement but it definitely doesn't belong here.
             UpdateInvertY();
@@ -109,5 +106,21 @@ public class MouseLook : MonoBehaviour
     public void setSensitivity(float sensitivity)
     {
         _sensitivity = sensitivity;
+    }
+
+    public void CopyRotationCoordinates(MouseLook mouseLook)
+    {
+        _xRotation = mouseLook.GetXRotation();
+        _yRotation = mouseLook.GetYRotation();
+    }
+
+    public float GetXRotation()
+    {
+        return _xRotation;
+    }
+    
+    public float GetYRotation()
+    {
+        return _yRotation;
     }
 }


### PR DESCRIPTION
Now the camera has always the same orientation when switching between modes