### PR TITLE
Keep same rotation after respawn

### DIFF
--- a/Assets/Code/Scripts/LevelManagement/RespawningManager.cs
+++ b/Assets/Code/Scripts/LevelManagement/RespawningManager.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using POLIMIGameCollective;
 using Unity.VisualScripting;
 using UnityEngine;
 
@@ -50,6 +51,7 @@ public class RespawningManager : MonoBehaviour
             _childrenTransforms[i].rotation = _lastCheckPointChildrenRotations[i];
         }
         _realityMovement.ResetSpeedOnRespawn();
+        EventManager.TriggerEvent("SetLastCheckpointRotation");    
     }
 
     /// <summary>
@@ -68,6 +70,7 @@ public class RespawningManager : MonoBehaviour
             _lastCheckPointChildrenPositions.Add(childTransform.position);
             _lastCheckPointChildrenRotations.Add(childTransform.rotation);
         }
+        EventManager.TriggerEvent("StoreCheckpointRotation");
     }
     
     /// <summary>

--- a/Assets/Code/Scripts/PlayerManagement/MouseLook.cs
+++ b/Assets/Code/Scripts/PlayerManagement/MouseLook.cs
@@ -15,6 +15,7 @@ public class MouseLook : MonoBehaviour
     private bool _activeScript = true;
     
     // link camera to body
+    // TODO check the right name for the orientation: in this way are a little confusing terms
     [Tooltip("Indicates the gameobject that has the orientation information: could be also the gameobject that own this script")]
     [SerializeField] private Transform _orientation;
     
@@ -29,8 +30,10 @@ public class MouseLook : MonoBehaviour
     private bool _activeCurrently;
     private Transform _transform;
 
-    private float _yRotation = 0f; // yaw movement variable
-    private float _xRotation = 0f; // pitch movement variable
+    private float _yRotation; // yaw movement variable
+    private float _yRotationCheckpoint;
+    private float _xRotation; // pitch movement variable
+    private float _xRotationCheckpoint;
     private int _invertY = 1;
     private void Awake()
     {
@@ -47,11 +50,10 @@ public class MouseLook : MonoBehaviour
     void Start()
     {
         EventManager.StartListening("setSensitivity", SetSensitivityFromPause);
-       
-
+        EventManager.StartListening("StoreCheckpointRotation", StoreCheckpointRotation);
+        EventManager.StartListening("SetLastCheckpointRotation", SetLastCheckpointRotation);
         Cursor.lockState = CursorLockMode.Locked;
         Cursor.visible = false;
-        
     }
     
     void Update()
@@ -77,12 +79,7 @@ public class MouseLook : MonoBehaviour
             _yRotation += mouseX; // the x screen axis corresponds to a rotation on the y axis of the camera 
             _xRotation -= mouseY; // the y screen axis corresponds to a rotation on the x axis of the camera 
             _xRotation = Mathf.Clamp(_xRotation, -90f, 90f);    // Clamping allows to block the rotation
-            
-            // TODO check the right name for the orientation: in this way are a little confusing terms
-            
-            // IMPORTANT: Don't change the order of the two following lines: if _orientation and _transform are the same gameobject it doesn't work due to value override.
-            _orientation.rotation = Quaternion.Euler(0, _yRotation, 0);  // updates the orientation of the gameobject that has the orientation information of the camera on the y axis
-            _transform.rotation = Quaternion.Euler(_xRotation*_invertY, _yRotation, 0);  // updates the camera orientation
+            UpdateRotation();
             
             // Checks whether there's local information about vertical axis preference and changes it.
             // I don't know the cost of this statement but it definitely doesn't belong here.
@@ -120,6 +117,7 @@ public class MouseLook : MonoBehaviour
     {
         _xRotation = mouseLook.GetXRotation();
         _yRotation = mouseLook.GetYRotation();
+        UpdateRotation();
     }
 
     public float GetXRotation()
@@ -136,6 +134,7 @@ public class MouseLook : MonoBehaviour
     private void SetSensitivityFromPause(string sensitivityPlaceholder)
     {
         EventManager.StopListening("setSensitivity", SetSensitivityFromPause);
+        Debug.Log("SetSensitivityFromPause");
         StartCoroutine(SetSensitivityFromPauseCoroutine(sensitivityPlaceholder));
         EventManager.StartListening("setSensitivity", SetSensitivityFromPause);
     }
@@ -144,5 +143,25 @@ public class MouseLook : MonoBehaviour
     {
         _sensitivity = float.Parse(sensitivityPlaceholder);
         yield return null;
+    }
+
+    private void StoreCheckpointRotation()
+    {
+        _xRotationCheckpoint = _xRotation;
+        _yRotationCheckpoint = _yRotation;
+    }
+
+    private void SetLastCheckpointRotation()
+    {
+        _xRotation = _xRotationCheckpoint;
+        _yRotation = _yRotationCheckpoint;
+        UpdateRotation();
+    }
+
+    private void UpdateRotation()
+    {
+        // IMPORTANT: Don't change the order of the two following lines: if _orientation and _transform are the same gameobject it doesn't work due to value override.
+        _orientation.rotation = Quaternion.Euler(0, _yRotation, 0);  // updates the orientation of the gameobject that has the orientation information of the camera on the y axis
+        _transform.rotation = Quaternion.Euler(_xRotation*_invertY, _yRotation, 0);  // updates the camera orientation
     }
 }

--- a/Assets/Code/Scripts/PlayerManagement/RealityPlayerCollisions.cs
+++ b/Assets/Code/Scripts/PlayerManagement/RealityPlayerCollisions.cs
@@ -1,4 +1,3 @@
-using System;
 using POLIMIGameCollective;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -27,7 +26,6 @@ public class RealityPlayerCollisions : MonoBehaviour
         else if (other.CompareTag("Checkpoint"))
         {
             other.GetComponent<AnchorCheckpointController>().ReactToPlayerCollision();
-            _respawningManager.UpdateCheckpointValues();
         }
         else if (other.CompareTag("OutOfBounds"))
         {
@@ -49,6 +47,9 @@ public class RealityPlayerCollisions : MonoBehaviour
         if (other.CompareTag("NoclipEnabler"))
         {
             _noclipManager.SetPlayerCanEnableNoClip(false);
+        } else if (other.CompareTag("Checkpoint"))
+        {
+            _respawningManager.UpdateCheckpointValues();
         }
     }
 }

--- a/Assets/Level/Prefabs/BuildingBlocks/SpawnPlatform.prefab
+++ b/Assets/Level/Prefabs/BuildingBlocks/SpawnPlatform.prefab
@@ -32,6 +32,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 5361369008084031658}
+  - {fileID: 4056570737090458121}
   - {fileID: 3608855251931857515}
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -185,7 +186,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8911350198173559643}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &3287363267589064112
 MeshFilter:
@@ -249,4 +250,58 @@ BoxCollider:
   m_Enabled: 1
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &7280355292445905055
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4056570737090458121}
+  - component: {fileID: 1406755642347547978}
+  - component: {fileID: 3605231197215099183}
+  m_Layer: 0
+  m_Name: Checkpoint
+  m_TagString: Checkpoint
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4056570737090458121
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7280355292445905055}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8911350198173559643}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &1406755642347547978
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7280355292445905055}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!135 &3605231197215099183
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7280355292445905055}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
   m_Center: {x: 0, y: 0, z: 0}


### PR DESCRIPTION
- I created an `UpdateRotation()` function, I think that calling this function everytime we update the _xRotation and _yRotation makes the transition a bit smoother (there was a comment from Tizio about this)
- I relied on 2 events to store and set the coordinates after a respawn (`SetLastCheckpointRotation `and `StoreLastCheckpointRotation`). I do not stop the listening of these events, as it is not harmful if they are triggered twice in a row.
- I did a minor modification to spawnplatform, now it has a checkpoint. In this way, we save the rotation coordinates also when we exit from the spawn platform