### PR TITLE
Fixed audio slider consistency

### DIFF
--- a/Assets/Code/Scripts/MenuManagement/LoadPrefs.cs
+++ b/Assets/Code/Scripts/MenuManagement/LoadPrefs.cs
@@ -22,7 +22,9 @@ public class LoadPrefs : MonoBehaviour
 
     [Header("Volume Settings")] 
     [SerializeField] private TMP_Text volumeTextValue;
-    [SerializeField] private Slider volumeSlider = null;
+    [SerializeField] private Slider globalVolumeSlider = null;
+    [SerializeField] private Slider effectsVolumeSlider = null;
+    [SerializeField] private Slider soundtrackVolumeSlider = null;
     [SerializeField] private AudioMixer audioMixer;
 
     [Header("Quality Level Settings")]
@@ -49,7 +51,7 @@ public class LoadPrefs : MonoBehaviour
                 float localSoundVolume = PlayerPrefs.GetFloat("soundtrackVolume");
                 Debug.Log("local volume menu " + localSoundVolume);
                 
-                volumeSlider.value = localSoundVolume;
+                soundtrackVolumeSlider.value = localSoundVolume;
                 audioMixer.SetFloat("soundtrackVolume", Mathf.Log(localSoundVolume) * 20);
             }
             
@@ -59,7 +61,7 @@ public class LoadPrefs : MonoBehaviour
                 
                 float localEffectsVolume = PlayerPrefs.GetFloat("effectsVolume");
                 
-                volumeSlider.value = localEffectsVolume;
+                effectsVolumeSlider.value = localEffectsVolume;
                 audioMixer.SetFloat("effectsVolume", Mathf.Log(localEffectsVolume) * 20);
             }
 
@@ -69,7 +71,7 @@ public class LoadPrefs : MonoBehaviour
                 
                 float localGlobalVolume = PlayerPrefs.GetFloat("globalVolume");
 
-                volumeSlider.value = localGlobalVolume;
+                globalVolumeSlider.value = localGlobalVolume;
                 audioMixer.SetFloat("globalVolume", Mathf.Log(localGlobalVolume) * 20);
             }
             

--- a/Assets/Code/Scripts/MenuManagement/LoadPrefs.cs
+++ b/Assets/Code/Scripts/MenuManagement/LoadPrefs.cs
@@ -53,7 +53,7 @@ public class LoadPrefs : MonoBehaviour
                 audioMixer.SetFloat("soundtrackVolume", Mathf.Log(localSoundVolume) * 20);
             }
             
-            
+
             if (PlayerPrefs.HasKey("effectsVolume"))
             {
                 

--- a/Assets/Code/Scripts/MenuManagement/MenuController.cs
+++ b/Assets/Code/Scripts/MenuManagement/MenuController.cs
@@ -169,7 +169,7 @@ public class MenuController : MonoBehaviour
     public void SetControllerSensitivity(float sensitivity)
     {
         mainControllerSensitivity = Mathf.RoundToInt(sensitivity);
-        controllerSensitivityTextValue.text = sensitivity.ToString("0");
+        PlayerPrefs.SetFloat("masterSensitivity", mainControllerSensitivity);
     }
     
     // Applies changes. These actually save the information.

--- a/Assets/Code/Scripts/MenuManagement/MenuController.cs
+++ b/Assets/Code/Scripts/MenuManagement/MenuController.cs
@@ -147,6 +147,7 @@ public class MenuController : MonoBehaviour
     {
         _currentSoundVolume = volume;
         audioMixer.SetFloat("soundtrackVolume", Mathf.Log(_currentSoundVolume) * 20);
+        PlayerPrefs.SetFloat("soundtrackVolume", _currentSoundVolume);
 
     }
     
@@ -154,6 +155,7 @@ public class MenuController : MonoBehaviour
     {
         _currentGlobalVolume = volume;
         audioMixer.SetFloat("globalVolume", Mathf.Log(_currentGlobalVolume) * 20);
+        PlayerPrefs.SetFloat("globalVolume", _currentGlobalVolume);
 
     }
     
@@ -161,6 +163,7 @@ public class MenuController : MonoBehaviour
     {
         _currentEffectsVolume = volume;
         audioMixer.SetFloat("effectsVolume", Mathf.Log(_currentEffectsVolume) * 20);
+        PlayerPrefs.SetFloat("effectsVolume", _currentEffectsVolume);
 
     }
     public void SetControllerSensitivity(float sensitivity)

--- a/Assets/Code/Scripts/MenuManagement/PauseMenuController.cs
+++ b/Assets/Code/Scripts/MenuManagement/PauseMenuController.cs
@@ -69,9 +69,9 @@ public class PauseMenuController : MonoBehaviour
 
     private void Start()
     {
-        SetVolumeEffects(PlayerPrefs.GetFloat("effectsVolume"));
-        SetVolumeGlobal(PlayerPrefs.GetFloat("globalVolume"));
-        SetVolumeSoundtrack(PlayerPrefs.GetFloat("soundtrackVolume"));
+        SetEffectsVolume(PlayerPrefs.GetFloat("effectsVolume"));
+        SetGlobalVolume(PlayerPrefs.GetFloat("globalVolume"));
+        SetSoundtrackVolume(PlayerPrefs.GetFloat("soundtrackVolume"));
     }
     private void Update()
     {
@@ -90,9 +90,9 @@ public class PauseMenuController : MonoBehaviour
 
     public void ActivateMenu()
     {
-        SetVolumeEffects(PlayerPrefs.GetFloat("effectsVolume"));
-        SetVolumeGlobal(PlayerPrefs.GetFloat("globalVolume"));
-        SetVolumeSoundtrack(PlayerPrefs.GetFloat("soundtrackVolume"));
+        SetEffectsVolume(PlayerPrefs.GetFloat("effectsVolume"));
+        SetGlobalVolume(PlayerPrefs.GetFloat("globalVolume"));
+        SetSoundtrackVolume(PlayerPrefs.GetFloat("soundtrackVolume"));
         
 
         Time.timeScale = 0;
@@ -111,7 +111,7 @@ public class PauseMenuController : MonoBehaviour
 
     public void DeactivateMenu()
     {
-        SetVolumeGlobal(PlayerPrefs.GetFloat("soundtrackVolume"));
+        SetGlobalVolume(PlayerPrefs.GetFloat("soundtrackVolume"));
         Time.timeScale = 1;
         AudioListener.pause = false;
 
@@ -170,23 +170,23 @@ public class PauseMenuController : MonoBehaviour
         EventManager.TriggerEvent("setSensitivity", sensitivity.ToString());
         mainControllerSensitivity = Mathf.RoundToInt(sensitivity);
     }
-    public void SetVolumeSoundtrack(float volume)
+    public void SetSoundtrackVolume(float volume)
     {
         _currentSoundVolume = volume;
         _audioMixer.SetFloat("soundtrackVolume", Mathf.Log(_currentSoundVolume) * 20);
-        _volumeSoundtrackSlider.value = volume;
+        PlayerPrefs.SetFloat("soundtrackVolume", _currentSoundVolume);
     }
-    public void SetVolumeEffects(float volume)
+    public void SetEffectsVolume(float volume)
     {
         _currentEffectsVolume = volume;
         _audioMixer.SetFloat("effectsVolume", Mathf.Log(_currentEffectsVolume) * 20);
-        _volumeEffectsSlider.value = volume;
+        PlayerPrefs.SetFloat("effectsVolume", _currentEffectsVolume);
     }
-    public void SetVolumeGlobal(float volume)
+    public void SetGlobalVolume(float volume)
     {
         _currentGlobalVolume = volume;
         _audioMixer.SetFloat("globalVolume", Mathf.Log(_currentGlobalVolume) * 20);
-        _volumeGlobalSlider.value = volume;
+        PlayerPrefs.SetFloat("globalVolume", _currentGlobalVolume);
     }
     public void GameplayApply()
     {

--- a/Assets/Level/Scenes/Common/PauseMenuUI_v2.unity
+++ b/Assets/Level/Scenes/Common/PauseMenuUI_v2.unity
@@ -11180,7 +11180,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 544627111}
         m_TargetAssemblyTypeName: PauseMenuController, Assembly-CSharp
-        m_MethodName: SetVolumeEffects
+        m_MethodName: SetEffectsVolume
         m_Mode: 0
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -11413,7 +11413,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 544627111}
         m_TargetAssemblyTypeName: PauseMenuController, Assembly-CSharp
-        m_MethodName: SetVolumeGlobal
+        m_MethodName: SetGlobalVolume
         m_Mode: 0
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -12773,7 +12773,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 544627111}
         m_TargetAssemblyTypeName: PauseMenuController, Assembly-CSharp
-        m_MethodName: SetVolumeSoundtrack
+        m_MethodName: SetSoundtrackVolume
         m_Mode: 0
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/Assets/Level/Scenes/Menu_0.unity
+++ b/Assets/Level/Scenes/Menu_0.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.22031568, g: 0.48526186, b: 0.78091514, a: 1}
+  m_IndirectSpecularColor: {r: 0.2203154, g: 0.48526037, b: 0.78091484, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -7244,7 +7244,9 @@ MonoBehaviour:
   canUse: 1
   menuController: {fileID: 771194624}
   volumeTextValue: {fileID: 0}
-  volumeSlider: {fileID: 1882909496}
+  globalVolumeSlider: {fileID: 2108244910}
+  effectsVolumeSlider: {fileID: 82562097}
+  soundtrackVolumeSlider: {fileID: 1882909496}
   audioMixer: {fileID: 24100000, guid: 966f75dff49d65b4a9d6827eea13a365, type: 2}
   qualityDropdown: {fileID: 383834417}
   fullScreenToggle: {fileID: 1396441972}


### PR DESCRIPTION
A brief PR. 

- Added a reference to the other sliders in `LoadPrefs.cs`. Yes, it's that dumb.
- Slider value now updates each time a menu / pause menu is started. This ensures data consistency between the two, ensuring the player doesn't get confused. 
- Slider value updates `PlayerPrefs` while sliding.
- Also, a few words on `PlayerPrefs`. They work fine, and further audio structure is not needed. At least, that's what I'm noticing after doing this fix. Now that everything _seems_ consistent, working with an audio mixer will not be as hard.

Nice!