### PR TITLE
Add skybox materials definition inside the areaManager

### DIFF
--- a/Assets/Code/ScriptableObjects/NoclipOptions.cs
+++ b/Assets/Code/ScriptableObjects/NoclipOptions.cs
@@ -11,10 +11,6 @@ namespace Code.ScriptableObjects
         [Header("Control the hints we give to the player")]
         public string howToActivateNoclip = "hold right click to noclip";
         public string tryToActivateNoclipOutside = "you cannot noclip here";
-
-        [Header("Skybox change")]
-        public Material realitySkyboxMaterial;
-        public Material noClipSkyboxMaterial;
         
         [Header("Default materials for objects when we are in noclip mode")] 
         public Material[] noClipMaterialsForRealityObjects;

--- a/Assets/Code/Scripts/NoclipRealityManagement/NoclipManager.cs
+++ b/Assets/Code/Scripts/NoclipRealityManagement/NoclipManager.cs
@@ -47,7 +47,6 @@ public class NoclipManager : MonoBehaviour
     void Awake()
     {
         _cameraManager = FindObjectOfType<CameraManager>();
-        RenderSettings.skybox = _noclipOptions.realitySkyboxMaterial;
         GetReadyForPuzzle();
         _noclipZoneAudioSource.volume = _audioTracks.noClipSoundVolumeMultiplier;
         _noclipMovement = _noclipCamera.GetComponent<NoclipMovement>();
@@ -294,7 +293,7 @@ public class NoclipManager : MonoBehaviour
 
     private void RenderNoclipMode()
     {
-        RenderSettings.skybox = _noclipOptions.noClipSkyboxMaterial;
+        EventManager.TriggerEvent("SetNoclipSkybox");
         foreach (var objectMaterialSwitcher in _objectMaterialSwitchers)
         {
             if(objectMaterialSwitcher != null)
@@ -306,7 +305,7 @@ public class NoclipManager : MonoBehaviour
     
     private void RenderRealityMode()
     {
-        RenderSettings.skybox = _noclipOptions.realitySkyboxMaterial;
+        EventManager.TriggerEvent("SetRealitySkybox");
         foreach (var objectMaterialSwitcher in _objectMaterialSwitchers)
         {
             if(objectMaterialSwitcher != null)

--- a/Assets/Code/Scripts/Utils/SkyboxManagerController.cs
+++ b/Assets/Code/Scripts/Utils/SkyboxManagerController.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using POLIMIGameCollective;
+using UnityEngine;
+
+namespace Code.Scripts.Utils
+{
+    public class SkyboxManagerController : MonoBehaviour
+    {
+        [SerializeField] private Material _realitySkybox;
+        [SerializeField] private Material _noclipSkybox;
+
+        private void Awake()
+        {
+            SetRealitySkybox();
+            EventManager.StartListening("SetRealitySkybox", SetRealitySkybox);
+            EventManager.StartListening("SetNoclipSkybox", SetNoclipSkybox);
+        }
+
+        public void SetRealitySkybox()
+        {
+            RenderSettings.skybox = _realitySkybox;
+        }
+
+        public void SetNoclipSkybox()
+        {
+            RenderSettings.skybox = _noclipSkybox;
+        }
+    }
+}

--- a/Assets/Code/Scripts/Utils/SkyboxManagerController.cs.meta
+++ b/Assets/Code/Scripts/Utils/SkyboxManagerController.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1b13099bc1b843c4887ad81d719d99e3
+timeCreated: 1672478433

--- a/Assets/Level/Prefabs/AreaManager.prefab
+++ b/Assets/Level/Prefabs/AreaManager.prefab
@@ -239,7 +239,7 @@ GameObject:
   - component: {fileID: 2432956645583729994}
   m_Layer: 0
   m_Name: SkyboxManager
-  m_TagString: SkyboxManager
+  m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Level/Prefabs/AreaManager.prefab
+++ b/Assets/Level/Prefabs/AreaManager.prefab
@@ -175,6 +175,7 @@ Transform:
   m_Children:
   - {fileID: 4755851670936372079}
   - {fileID: 6808108631478938220}
+  - {fileID: 3302489467471476068}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -226,3 +227,49 @@ MonoBehaviour:
   - PauseMenuUI_v2
   - SceneWithPlayer
   - GUI
+--- !u!1 &9109041096669486898
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3302489467471476068}
+  - component: {fileID: 2432956645583729994}
+  m_Layer: 0
+  m_Name: SkyboxManager
+  m_TagString: SkyboxManager
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3302489467471476068
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9109041096669486898}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1832818251895023719}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2432956645583729994
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9109041096669486898}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1b13099bc1b843c4887ad81d719d99e3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _realitySkybox: {fileID: 2100000, guid: ff628d98ed3254a42ada14b0785449b7, type: 2}
+  _noclipSkybox: {fileID: 2100000, guid: d6a9b2e27dec58c41bd10e8440b553d7, type: 2}

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -20,7 +20,6 @@ TagManager:
   - ProgressSaver
   - Background
   - DialogueBox
-  - SkyboxManager
   layers:
   - Default
   - TransparentFX

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -20,6 +20,7 @@ TagManager:
   - ProgressSaver
   - Background
   - DialogueBox
+  - SkyboxManager
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
Now, for each area, you can decide the skybox for noclip and reality mode independently from other areas.

This can be done from the area manager:
![image](https://user-images.githubusercontent.com/36990714/210131908-8d43bc3f-24fe-4f46-a809-41d23b3273aa.png)
