### PR TITLE
Simplify TimeConstraints and fix all the bugs (hopefully!)

### DIFF
--- a/Assets/Code/Scripts/LevelManagement/RespawningManager.cs
+++ b/Assets/Code/Scripts/LevelManagement/RespawningManager.cs
@@ -114,7 +114,6 @@ public class RespawningManager : MonoBehaviour
         // Switch to reality camera after the animation is complete
         _cameraManager.SwitchCamera(false);
         _realityMovement.ResetSpeedOnRespawn();
-        EventManager.TriggerEvent("StartTimeConstraintsTimer");
         _noclipManager.SetAcceptUserInput(true);
         _respawnAnimationIsRunning = false;
         yield return null;
@@ -142,7 +141,6 @@ public class RespawningManager : MonoBehaviour
         _realityMovement.ResetSpeedOnRespawn();
         EventManager.TriggerEvent("SetLastCheckpointRotation");
         EventManager.TriggerEvent("ResetTimeLimitConstraints");
-        EventManager.TriggerEvent("StartTimeConstraintsTimer");
         _noclipManager.SetAcceptUserInput(true);
     }
     

--- a/Assets/Code/Scripts/MenuManagement/PauseMenuController.cs
+++ b/Assets/Code/Scripts/MenuManagement/PauseMenuController.cs
@@ -97,6 +97,7 @@ public class PauseMenuController : MonoBehaviour
 
         Time.timeScale = 0;
         AudioListener.pause = false;
+        EventManager.TriggerEvent("PauseTimeConstraintsTimer");
         
         _menuPress.ignoreListenerPause=true;
         _menuPress.Play();
@@ -114,6 +115,7 @@ public class PauseMenuController : MonoBehaviour
         SetGlobalVolume(PlayerPrefs.GetFloat("soundtrackVolume"));
         Time.timeScale = 1;
         AudioListener.pause = false;
+        EventManager.TriggerEvent("ResumeTimeConstraintsTimer");
 
         _menuPress.Play();
         

--- a/Assets/Code/Scripts/NoclipRealityManagement/NoclipManager.cs
+++ b/Assets/Code/Scripts/NoclipRealityManagement/NoclipManager.cs
@@ -122,6 +122,7 @@ public class NoclipManager : MonoBehaviour
     {
         EventManager.TriggerEvent("ClearHints");
         _noclipState = NoclipState.NoclipEnabled;
+        EventManager.TriggerEvent("StopTimeConstraintsTimer");
         _postprocessReality.SetActive(false);
         _postprocessNoclip.SetActive(true);
         
@@ -159,6 +160,7 @@ public class NoclipManager : MonoBehaviour
         });
         _cameraManager.SwitchCamera();
         RenderRealityMode();
+        EventManager.TriggerEvent("ResumeTimeConstraintsTimer");
         yield return null;
     }
 

--- a/Assets/Code/Scripts/NoclipRealityManagement/NoclipManager.cs
+++ b/Assets/Code/Scripts/NoclipRealityManagement/NoclipManager.cs
@@ -122,7 +122,7 @@ public class NoclipManager : MonoBehaviour
     {
         EventManager.TriggerEvent("ClearHints");
         _noclipState = NoclipState.NoclipEnabled;
-        EventManager.TriggerEvent("StopTimeConstraintsTimer");
+        EventManager.TriggerEvent("PauseTimeConstraintsTimer");
         _postprocessReality.SetActive(false);
         _postprocessNoclip.SetActive(true);
         

--- a/Assets/Code/Scripts/PlayerManagement/RealityPlayerCollisions.cs
+++ b/Assets/Code/Scripts/PlayerManagement/RealityPlayerCollisions.cs
@@ -48,7 +48,7 @@ public class RealityPlayerCollisions : MonoBehaviour
             _noclipManager.SetPlayerIsInsideNoclipEnabler(false);
         } else if (other.CompareTag("Checkpoint"))
         {
-            EventManager.TriggerEvent("StartTimeConstraintsTimer");
+            EventManager.TriggerEvent("RestartTimeConstraintsTimer");
         }
     }
 }

--- a/Assets/Code/Scripts/PlayerManagement/TimeConstraints.cs
+++ b/Assets/Code/Scripts/PlayerManagement/TimeConstraints.cs
@@ -25,7 +25,7 @@ namespace Code.Scripts.PlayerManagement
             EventManager.StartListening("ResetTimeLimitConstraints", ResetTimeLimitConstraints);
             EventManager.StartListening("RestartTimeConstraintsTimer", RestartTimeConstraintsTimer);
             EventManager.StartListening("ResumeTimeConstraintsTimer", ResumeTimeConstraintsTimer);
-            EventManager.StartListening("StopTimeConstraintsTimer", StopTimeConstraintsTimer);
+            EventManager.StartListening("PauseTimeConstraintsTimer", PauseTimeConstraintsTimer);
         }
 
         void Update()
@@ -99,7 +99,7 @@ namespace Code.Scripts.PlayerManagement
             EventManager.TriggerEvent("GuiResumeTimer");
         }
         
-        private void StopTimeConstraintsTimer()
+        private void PauseTimeConstraintsTimer()
         {
             if (!_timeLimitForPuzzleEnabled)
                 return;

--- a/Assets/Code/Scripts/PlayerManagement/TimeConstraints.cs
+++ b/Assets/Code/Scripts/PlayerManagement/TimeConstraints.cs
@@ -7,59 +7,37 @@ namespace Code.Scripts.PlayerManagement
 {
     public class TimeConstraints : MonoBehaviour
     {
-        private NoclipManager _noclipManager;
         private RespawningManager _respawningManager;
-        
+
         // If True, the player needs to finish the puzzle before _maxTimeToFinishPuzzle
         private bool _timeLimitForPuzzleEnabled;
         private float _maxTimeToFinishPuzzle;
-        
-        private float _realityTimeLeftInThisPuzzle;
-        private bool _timerWasActive;
 
+        private float _realityTimeLeftInThisPuzzle;
         private bool _isRunning;
 
         private void Awake()
         {
-            _noclipManager = GetComponent<NoclipManager>();
             _respawningManager = GetComponentInParent<RespawningManager>();
             ResetTimeLimitConstraints();
-            _timerWasActive = TimerShouldBeActive();
-            
+
             EventManager.StartListening("SetNewTimeLimitConstraint", SetNewTimeLimitConstraint);
             EventManager.StartListening("ResetTimeLimitConstraints", ResetTimeLimitConstraints);
-            EventManager.StartListening("StartTimeConstraintsTimer", StartTimeConstraintsTimer);
+            EventManager.StartListening("RestartTimeConstraintsTimer", RestartTimeConstraintsTimer);
+            EventManager.StartListening("ResumeTimeConstraintsTimer", ResumeTimeConstraintsTimer);
+            EventManager.StartListening("StopTimeConstraintsTimer", StopTimeConstraintsTimer);
         }
-        
+
         void Update()
         {
             if (!_timeLimitForPuzzleEnabled || !_isRunning)
                 return;
 
-            ResumeOrPauseGuiTimer();
-            
-            if (!TimerShouldBeActive())
-                return;
-            
             _realityTimeLeftInThisPuzzle -= Time.deltaTime;
             if (_realityTimeLeftInThisPuzzle <= 0)
                 StartCoroutine(GameLostCoroutine());
-            
         }
-        
-        /// <summary>
-        /// This function is ONLY to trigger the start/stop of the GUI
-        /// </summary>
-        private void ResumeOrPauseGuiTimer()
-        {
-            if (TimerShouldBeActive() && !_timerWasActive)
-                EventManager.TriggerEvent("GuiPauseTimer");
-            else if (!TimerShouldBeActive() && _timerWasActive)
-                EventManager.TriggerEvent("GuiResumeTimer");
 
-            _timerWasActive = TimerShouldBeActive();
-        }
-        
         /// <summary>
         /// Set the time that the player needs to finish this puzzle.
         /// IMPORTANT: if maxTimeToFinishPuzzle is '0', the puzzle does not have a time limit.
@@ -77,7 +55,7 @@ namespace Code.Scripts.PlayerManagement
                 Debug.Log($"Setting time constraint for this puzzle to {maxTimeToFinishPuzzle}");
                 _timeLimitForPuzzleEnabled = true;
             }
-            
+
             _maxTimeToFinishPuzzle = maxTimeToFinishPuzzle;
             ResetTimeLimitConstraints();
         }
@@ -86,9 +64,8 @@ namespace Code.Scripts.PlayerManagement
         {
             Debug.Log($"Resetting time limit constraints. Time to finish is {_maxTimeToFinishPuzzle}");
             _realityTimeLeftInThisPuzzle = _maxTimeToFinishPuzzle;
-            _timerWasActive = TimerShouldBeActive();
-            EventManager.TriggerEvent("GuiResetTimer", _maxTimeToFinishPuzzle.ToString());
             _isRunning = false;
+            EventManager.TriggerEvent("GuiResetTimer", _maxTimeToFinishPuzzle.ToString());
         }
 
         private IEnumerator GameLostCoroutine()
@@ -98,25 +75,36 @@ namespace Code.Scripts.PlayerManagement
             ResetTimeLimitConstraints();
             yield return null;
         }
-        
+
         /// <summary>
         /// Start the internal timer and triggers the GUI
         /// </summary>
-        private void StartTimeConstraintsTimer()
+        private void RestartTimeConstraintsTimer()
         {
             ResetTimeLimitConstraints();
-            
+
             if (!_timeLimitForPuzzleEnabled)
                 return;
-            
-            if (TimerShouldBeActive())
-                EventManager.TriggerEvent("GuiResumeTimer");
-            _isRunning = true;
-        }
 
-        private bool TimerShouldBeActive()
+            _isRunning = true;
+            EventManager.TriggerEvent("GuiResumeTimer");
+        }
+        
+        private void ResumeTimeConstraintsTimer()
         {
-            return _noclipManager.RealityPlayerCanMove();
+            if (!_timeLimitForPuzzleEnabled)
+                return;
+
+            _isRunning = true;
+            EventManager.TriggerEvent("GuiResumeTimer");
+        }
+        
+        private void StopTimeConstraintsTimer()
+        {
+            if (!_timeLimitForPuzzleEnabled)
+                return;
+            _isRunning = false;
+            EventManager.TriggerEvent("GuiPauseTimer");
         }
     }
 }


### PR DESCRIPTION
There were many bugs in my previous implementation of `TimeConstraints` since I did not properly update it after the changes to the noclip manager. 

Now, I have decoupled it from the noclip manager and I have added an event (**ResumeTimeConstraintsTimer**) and renamed StartTimeConstraintsTimer into **RestartTimeConstraintsTimer**. In addition, **PauseTimeConstraintsTimer** can be used to pause the time constraints. Before there was not such a function.

Maybe there are too many events there, and for sure this is not the most elegant solution. But I hope it makes it easier to handle and removes many bugs.. please let me know!