### PR TITLE
Move the StartListening invokation in Start(), so we can play directly from area_xx

### DIFF
--- a/Assets/Code/Scripts/Utils/SkyboxManagerController.cs
+++ b/Assets/Code/Scripts/Utils/SkyboxManagerController.cs
@@ -12,6 +12,10 @@ namespace Code.Scripts.Utils
         private void Awake()
         {
             SetRealitySkybox();
+        }
+
+        private void Start()
+        {
             EventManager.StartListening("SetRealitySkybox", SetRealitySkybox);
             EventManager.StartListening("SetNoclipSkybox", SetNoclipSkybox);
         }


### PR DESCRIPTION
I simply moved the usage of EventManager inside the Start method in the newly added `SkyboxManagerController`. If we keep it in awake, we cannot start to play from an area and we must start from 0_main, making the tests more difficult!


PS: sorry if I did not notice it before...