### PR TITLE
Fix bug when we skip the loading screen with some specific keys

### DIFF
--- a/Assets/Code/Scripts/LoadingManagement/LoadingScreenController.cs
+++ b/Assets/Code/Scripts/LoadingManagement/LoadingScreenController.cs
@@ -50,7 +50,7 @@ public class LoadingScreenController : MonoBehaviour
 
         if (_isLoaded)
         {
-            if (Input.anyKey && !(Input.GetButton("Jump") || Input.GetButton("NextPuzzle")))  // These two key are excluded because of possible bugs in the area after the loading screen
+            if (Input.anyKey && !Input.GetButton("NextPuzzle"))  // These two key are excluded because of possible bugs in the area after the loading screen
             {
                 _loadingSceneOption.ChangeSceneNumber();
                 GameObject.Find("GameManager").GetComponent<GameManager>().SetAreaFinished();

--- a/Assets/Code/Scripts/LoadingManagement/LoadingScreenController.cs
+++ b/Assets/Code/Scripts/LoadingManagement/LoadingScreenController.cs
@@ -50,7 +50,7 @@ public class LoadingScreenController : MonoBehaviour
 
         if (_isLoaded)
         {
-            if (Input.anyKey)
+            if (Input.anyKey && !(Input.GetButton("Jump") || Input.GetButton("NextPuzzle")))  // These two key are excluded because of possible bugs in the area after the loading screen
             {
                 _loadingSceneOption.ChangeSceneNumber();
                 GameObject.Find("GameManager").GetComponent<GameManager>().SetAreaFinished();


### PR DESCRIPTION
This bugfix avoid the player to cause bug:
In order to close the loading screen the TAB button and the Jump button aren't allowed