### PR TITLE
Expose noclip cooldown time parameter and default it to 0

### DIFF
--- a/Assets/Code/ScriptableObjects/DefaultNoclipOptions.asset
+++ b/Assets/Code/ScriptableObjects/DefaultNoclipOptions.asset
@@ -12,15 +12,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9da9a91fd94d4d6885289d5470f6c31d, type: 3}
   m_Name: DefaultNoclipOptions
   m_EditorClassIdentifier: 
-  noclipKey: 324
+  cooldownSeconds: 0
+  backToBodyAnimationDuration: 1
   howToActivateNoclip: hold right click to noclip
-  howToDeactivateNoclip: 
   tryToActivateNoclipOutside: you cannot noclip here
-  tryToDeactivateNoclipOutside: 
-  realitySkyboxMaterial: {fileID: 2100000, guid: ff628d98ed3254a42ada14b0785449b7,
-    type: 2}
-  noClipSkyboxMaterial: {fileID: 2100000, guid: d6a9b2e27dec58c41bd10e8440b553d7,
-    type: 2}
   noClipMaterialsForRealityObjects:
   - {fileID: 2100000, guid: 908ce36e679f17940bb6737cbce0e2ad, type: 2}
   - {fileID: 2100000, guid: 9f3270508c2881343b22409bc9df850c, type: 2}

--- a/Assets/Code/ScriptableObjects/NoclipOptions.cs
+++ b/Assets/Code/ScriptableObjects/NoclipOptions.cs
@@ -6,7 +6,8 @@ namespace Code.ScriptableObjects
     [CreateAssetMenu(menuName = "Noclip/Noclip Options")]
     public class NoclipOptions : ScriptableObject
     {
-        public float cooldownSeconds = 1f;
+        public float cooldownSeconds = 0;
+        public float backToBodyAnimationDuration = 0.5f;
         
         [Header("Control the hints we give to the player")]
         public string howToActivateNoclip = "hold right click to noclip";

--- a/Assets/Code/Scripts/NoclipRealityManagement/NoclipManager.cs
+++ b/Assets/Code/Scripts/NoclipRealityManagement/NoclipManager.cs
@@ -33,7 +33,6 @@ public class NoclipManager : MonoBehaviour
     
     private NoclipMovement _noclipMovement;
     private float _endCooldownAbsoluteTime;
-    private readonly float _backToBodyAnimationDuration = 0.5f;
 
     private enum NoclipState
     {
@@ -206,7 +205,7 @@ public class NoclipManager : MonoBehaviour
         while (!IsBackToBody())
         {
             timeElapsed += Time.deltaTime;
-            float t = timeElapsed / _backToBodyAnimationDuration;
+            float t = timeElapsed / _noclipOptions.backToBodyAnimationDuration;
             _noclipCamera.transform.position = Vector3.Lerp(startPosition, _realityCamera.transform.position, t);
             _noclipCamera.transform.rotation = Quaternion.Lerp(startAngle, _realityCamera.transform.rotation, t);
             yield return new WaitForEndOfFrame();
@@ -215,9 +214,10 @@ public class NoclipManager : MonoBehaviour
         yield return DisableNoclip();
         
         // Cooldown phase
-        _noclipState = NoclipState.RealityCooldown;
-        _endCooldownAbsoluteTime = Time.time + _noclipOptions.cooldownSeconds;
-        yield return new WaitForSecondsRealtime(_noclipOptions.cooldownSeconds);
+        if (_noclipOptions.cooldownSeconds > 0)
+            _noclipState = NoclipState.RealityCooldown;
+            _endCooldownAbsoluteTime = Time.time + _noclipOptions.cooldownSeconds;
+            yield return new WaitForSecondsRealtime(_noclipOptions.cooldownSeconds);
         
         // Cooldown is over, update noclipState!
         if (_playerInsideNoclipEnabler)


### PR DESCRIPTION
As requested, `cooldownTime` is now a public parameter in the noclipOptions and it is set to 0