### PR TITLE
Add empty object prefabs in the GUI scenes for score future implementation

### DIFF
--- a/Assets/Level/Prefabs/GUI/Score.meta
+++ b/Assets/Level/Prefabs/GUI/Score.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fc47d3000ea29d847bac10ff473e1c1c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Level/Prefabs/GUI/Score/ScoreInGameGui.prefab
+++ b/Assets/Level/Prefabs/GUI/Score/ScoreInGameGui.prefab
@@ -1,0 +1,38 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2586760911985256716
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3995351500458497040}
+  m_Layer: 5
+  m_Name: ScoreInGameGui
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3995351500458497040
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2586760911985256716}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}

--- a/Assets/Level/Prefabs/GUI/Score/ScoreInGameGui.prefab.meta
+++ b/Assets/Level/Prefabs/GUI/Score/ScoreInGameGui.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 92ecb1887e8118f4cb1fc38863f3abb0
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Level/Prefabs/GUI/Score/ScoreInPauseMenu.prefab
+++ b/Assets/Level/Prefabs/GUI/Score/ScoreInPauseMenu.prefab
@@ -1,0 +1,38 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &7033743600402829645
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3896494187227176109}
+  m_Layer: 5
+  m_Name: ScoreInPauseMenu
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3896494187227176109
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7033743600402829645}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}

--- a/Assets/Level/Prefabs/GUI/Score/ScoreInPauseMenu.prefab.meta
+++ b/Assets/Level/Prefabs/GUI/Score/ScoreInPauseMenu.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7f6ed1c17b24a314ca43a09c8193903f
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Level/Prefabs/GUI/Score/ScoreMainMenu.prefab
+++ b/Assets/Level/Prefabs/GUI/Score/ScoreMainMenu.prefab
@@ -1,0 +1,38 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2456275170870174080
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4771829561229946740}
+  m_Layer: 5
+  m_Name: ScoreMainMenu
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4771829561229946740
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2456275170870174080}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -0.009735094}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}

--- a/Assets/Level/Prefabs/GUI/Score/ScoreMainMenu.prefab.meta
+++ b/Assets/Level/Prefabs/GUI/Score/ScoreMainMenu.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a5986b5d60f20f34bb4542890c0dc1e1
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Level/Scenes/Common/GUI.unity
+++ b/Assets/Level/Scenes/Common/GUI.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.12731749, g: 0.13414757, b: 0.1210787, a: 1}
+  m_IndirectSpecularColor: {r: 0.12731704, g: 0.13414727, b: 0.121078536, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -1266,6 +1266,7 @@ RectTransform:
   - {fileID: 209238014}
   - {fileID: 1944839554}
   - {fileID: 308000310}
+  - {fileID: 1444384355}
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1595,6 +1596,131 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 951079780}
   m_CullTransparentMesh: 1
+--- !u!1001 &1444384354
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 677278140}
+    m_Modifications:
+    - target: {fileID: 2586760911985256716, guid: 92ecb1887e8118f4cb1fc38863f3abb0,
+        type: 3}
+      propertyPath: m_Name
+      value: ScoreInGameGui
+      objectReference: {fileID: 0}
+    - target: {fileID: 3995351500458497040, guid: 92ecb1887e8118f4cb1fc38863f3abb0,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3995351500458497040, guid: 92ecb1887e8118f4cb1fc38863f3abb0,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3995351500458497040, guid: 92ecb1887e8118f4cb1fc38863f3abb0,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3995351500458497040, guid: 92ecb1887e8118f4cb1fc38863f3abb0,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3995351500458497040, guid: 92ecb1887e8118f4cb1fc38863f3abb0,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3995351500458497040, guid: 92ecb1887e8118f4cb1fc38863f3abb0,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3995351500458497040, guid: 92ecb1887e8118f4cb1fc38863f3abb0,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3995351500458497040, guid: 92ecb1887e8118f4cb1fc38863f3abb0,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 3995351500458497040, guid: 92ecb1887e8118f4cb1fc38863f3abb0,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 3995351500458497040, guid: 92ecb1887e8118f4cb1fc38863f3abb0,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3995351500458497040, guid: 92ecb1887e8118f4cb1fc38863f3abb0,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3995351500458497040, guid: 92ecb1887e8118f4cb1fc38863f3abb0,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3995351500458497040, guid: 92ecb1887e8118f4cb1fc38863f3abb0,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3995351500458497040, guid: 92ecb1887e8118f4cb1fc38863f3abb0,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3995351500458497040, guid: 92ecb1887e8118f4cb1fc38863f3abb0,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3995351500458497040, guid: 92ecb1887e8118f4cb1fc38863f3abb0,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3995351500458497040, guid: 92ecb1887e8118f4cb1fc38863f3abb0,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3995351500458497040, guid: 92ecb1887e8118f4cb1fc38863f3abb0,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3995351500458497040, guid: 92ecb1887e8118f4cb1fc38863f3abb0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3995351500458497040, guid: 92ecb1887e8118f4cb1fc38863f3abb0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3995351500458497040, guid: 92ecb1887e8118f4cb1fc38863f3abb0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 92ecb1887e8118f4cb1fc38863f3abb0, type: 3}
+--- !u!224 &1444384355 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3995351500458497040, guid: 92ecb1887e8118f4cb1fc38863f3abb0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1444384354}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1506645597
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Level/Scenes/Common/PauseMenuUI_v2.unity
+++ b/Assets/Level/Scenes/Common/PauseMenuUI_v2.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.12731715, g: 0.13414735, b: 0.121078536, a: 1}
+  m_IndirectSpecularColor: {r: 0.12731704, g: 0.13414727, b: 0.121078536, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -11581,6 +11581,7 @@ RectTransform:
   m_Children:
   - {fileID: 1735504623}
   - {fileID: 623667504}
+  - {fileID: 1460626098}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -11962,6 +11963,146 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1441948226}
   m_CullTransparentMesh: 1
+--- !u!1001 &1460626097
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1349847167}
+    m_Modifications:
+    - target: {fileID: 3896494187227176109, guid: 7f6ed1c17b24a314ca43a09c8193903f,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3896494187227176109, guid: 7f6ed1c17b24a314ca43a09c8193903f,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3896494187227176109, guid: 7f6ed1c17b24a314ca43a09c8193903f,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3896494187227176109, guid: 7f6ed1c17b24a314ca43a09c8193903f,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3896494187227176109, guid: 7f6ed1c17b24a314ca43a09c8193903f,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3896494187227176109, guid: 7f6ed1c17b24a314ca43a09c8193903f,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3896494187227176109, guid: 7f6ed1c17b24a314ca43a09c8193903f,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3896494187227176109, guid: 7f6ed1c17b24a314ca43a09c8193903f,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 3896494187227176109, guid: 7f6ed1c17b24a314ca43a09c8193903f,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 3896494187227176109, guid: 7f6ed1c17b24a314ca43a09c8193903f,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 3.4362414
+      objectReference: {fileID: 0}
+    - target: {fileID: 3896494187227176109, guid: 7f6ed1c17b24a314ca43a09c8193903f,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 3.4362414
+      objectReference: {fileID: 0}
+    - target: {fileID: 3896494187227176109, guid: 7f6ed1c17b24a314ca43a09c8193903f,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 3.4362414
+      objectReference: {fileID: 0}
+    - target: {fileID: 3896494187227176109, guid: 7f6ed1c17b24a314ca43a09c8193903f,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3896494187227176109, guid: 7f6ed1c17b24a314ca43a09c8193903f,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3896494187227176109, guid: 7f6ed1c17b24a314ca43a09c8193903f,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3896494187227176109, guid: 7f6ed1c17b24a314ca43a09c8193903f,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3896494187227176109, guid: 7f6ed1c17b24a314ca43a09c8193903f,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3896494187227176109, guid: 7f6ed1c17b24a314ca43a09c8193903f,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3896494187227176109, guid: 7f6ed1c17b24a314ca43a09c8193903f,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3896494187227176109, guid: 7f6ed1c17b24a314ca43a09c8193903f,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -959.99994
+      objectReference: {fileID: 0}
+    - target: {fileID: 3896494187227176109, guid: 7f6ed1c17b24a314ca43a09c8193903f,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -539.48987
+      objectReference: {fileID: 0}
+    - target: {fileID: 3896494187227176109, guid: 7f6ed1c17b24a314ca43a09c8193903f,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3896494187227176109, guid: 7f6ed1c17b24a314ca43a09c8193903f,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3896494187227176109, guid: 7f6ed1c17b24a314ca43a09c8193903f,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7033743600402829645, guid: 7f6ed1c17b24a314ca43a09c8193903f,
+        type: 3}
+      propertyPath: m_Name
+      value: ScoreInPauseMenu
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7f6ed1c17b24a314ca43a09c8193903f, type: 3}
+--- !u!224 &1460626098 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3896494187227176109, guid: 7f6ed1c17b24a314ca43a09c8193903f,
+    type: 3}
+  m_PrefabInstance: {fileID: 1460626097}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1470978219
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Level/Scenes/Menu_0.unity
+++ b/Assets/Level/Scenes/Menu_0.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.21358685, g: 0.5025688, b: 0.8556069, a: 1}
+  m_IndirectSpecularColor: {r: 0.21356611, g: 0.50286126, b: 0.85569507, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -1117,6 +1117,7 @@ RectTransform:
   - {fileID: 586441864}
   - {fileID: 1265154173}
   - {fileID: 631149645}
+  - {fileID: 944765768}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -6422,6 +6423,131 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 927827096}
   m_CullTransparentMesh: 1
+--- !u!1001 &944765767
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 119334347}
+    m_Modifications:
+    - target: {fileID: 2456275170870174080, guid: a5986b5d60f20f34bb4542890c0dc1e1,
+        type: 3}
+      propertyPath: m_Name
+      value: ScoreMainMenu
+      objectReference: {fileID: 0}
+    - target: {fileID: 4771829561229946740, guid: a5986b5d60f20f34bb4542890c0dc1e1,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4771829561229946740, guid: a5986b5d60f20f34bb4542890c0dc1e1,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4771829561229946740, guid: a5986b5d60f20f34bb4542890c0dc1e1,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 4771829561229946740, guid: a5986b5d60f20f34bb4542890c0dc1e1,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4771829561229946740, guid: a5986b5d60f20f34bb4542890c0dc1e1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4771829561229946740, guid: a5986b5d60f20f34bb4542890c0dc1e1,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4771829561229946740, guid: a5986b5d60f20f34bb4542890c0dc1e1,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4771829561229946740, guid: a5986b5d60f20f34bb4542890c0dc1e1,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 4771829561229946740, guid: a5986b5d60f20f34bb4542890c0dc1e1,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 4771829561229946740, guid: a5986b5d60f20f34bb4542890c0dc1e1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4771829561229946740, guid: a5986b5d60f20f34bb4542890c0dc1e1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4771829561229946740, guid: a5986b5d60f20f34bb4542890c0dc1e1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4771829561229946740, guid: a5986b5d60f20f34bb4542890c0dc1e1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4771829561229946740, guid: a5986b5d60f20f34bb4542890c0dc1e1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4771829561229946740, guid: a5986b5d60f20f34bb4542890c0dc1e1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4771829561229946740, guid: a5986b5d60f20f34bb4542890c0dc1e1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4771829561229946740, guid: a5986b5d60f20f34bb4542890c0dc1e1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4771829561229946740, guid: a5986b5d60f20f34bb4542890c0dc1e1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -0.009735094
+      objectReference: {fileID: 0}
+    - target: {fileID: 4771829561229946740, guid: a5986b5d60f20f34bb4542890c0dc1e1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4771829561229946740, guid: a5986b5d60f20f34bb4542890c0dc1e1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4771829561229946740, guid: a5986b5d60f20f34bb4542890c0dc1e1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a5986b5d60f20f34bb4542890c0dc1e1, type: 3}
+--- !u!224 &944765768 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4771829561229946740, guid: a5986b5d60f20f34bb4542890c0dc1e1,
+    type: 3}
+  m_PrefabInstance: {fileID: 944765767}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &953935045
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
I have added 3 prefabs in the gui scenes. The prefabs are EMPTY OBJECTS, therefore there should not be any impact to the current behavior.

I need these prefabs as placeholder, so my branch with the score can have a final implementation without having conflicts (I will just modify the prefabs).