### PR TITLE
Add option to disable noclip hints in area manager

### DIFF
--- a/Assets/Code/Scripts/NoclipRealityManagement/NoclipHintsEnablerController.cs
+++ b/Assets/Code/Scripts/NoclipRealityManagement/NoclipHintsEnablerController.cs
@@ -1,0 +1,22 @@
+﻿using UnityEngine;
+
+namespace Code.Scripts.NoclipRealityManagement
+{
+    public class NoclipHintsEnablerController: MonoBehaviour
+    {
+        [SerializeField] private bool noclipHintsEnabled = true;
+
+        private void Start()
+        {
+            NoclipManager noclipManager = FindObjectOfType<NoclipManager>();
+            if (noclipManager != null)
+            {
+                Debug.Log("Noclipmanager has hints: " + noclipHintsEnabled);
+                noclipManager.SetHintsAreEnabled(noclipHintsEnabled);
+                return;
+            }
+
+            Debug.Log("noclipManager not found in the scene ...");
+        }
+    }
+}

--- a/Assets/Code/Scripts/NoclipRealityManagement/NoclipHintsEnablerController.cs.meta
+++ b/Assets/Code/Scripts/NoclipRealityManagement/NoclipHintsEnablerController.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 8af68a12c4a7487d90dbbb962040caf5
+timeCreated: 1673293638

--- a/Assets/Code/Scripts/NoclipRealityManagement/NoclipManager.cs
+++ b/Assets/Code/Scripts/NoclipRealityManagement/NoclipManager.cs
@@ -27,6 +27,7 @@ public class NoclipManager : MonoBehaviour
     private bool _playerInsideNoclipEnabler;
     private bool _insideNoclipAreaZoneIsPlaying;
     private bool _acceptUserInput = true;
+    private bool _hintsAreEnabled = true;
     private NoclipState _noclipState;
     
     private GameObject _postprocessReality;
@@ -114,7 +115,7 @@ public class NoclipManager : MonoBehaviour
         if (playerInsideNoclipEnabler && _noclipState == NoclipState.RealityCannotEnableNoclip)
         {
             if (_acceptUserInput)
-                EventManager.TriggerEvent("DisplayHint", _noclipOptions.howToActivateNoclip);
+                SendHint(_noclipOptions.howToActivateNoclip);
             _noclipState = NoclipState.RealityCanEnableNoclip;
             return;
         }
@@ -141,6 +142,11 @@ public class NoclipManager : MonoBehaviour
     public void SetAcceptUserInput(bool acceptUserInput)
     {
         _acceptUserInput = acceptUserInput;
+    }
+
+    public void SetHintsAreEnabled(bool hintsAreEnabled)
+    {
+        _hintsAreEnabled = hintsAreEnabled;
     }
 
     /// <summary>
@@ -241,10 +247,10 @@ public class NoclipManager : MonoBehaviour
                     break;
                 case NoclipState.RealityCooldown:
                     int secondsToWait = Mathf.CeilToInt(_endCooldownAbsoluteTime - Time.time);
-                    EventManager.TriggerEvent("DisplayHint", $"Noclip cooldown, wait {secondsToWait}s!");
+                    SendHint($"Noclip cooldown, wait {secondsToWait}s!");
                     break;
                 default:
-                    EventManager.TriggerEvent("DisplayHint", _noclipOptions.tryToActivateNoclipOutside);
+                    SendHint(_noclipOptions.tryToActivateNoclipOutside);
                     break;
             }
         }
@@ -287,7 +293,7 @@ public class NoclipManager : MonoBehaviour
         if (_playerInsideNoclipEnabler)
         {
             _noclipState = NoclipState.RealityCanEnableNoclip;
-            EventManager.TriggerEvent("DisplayHint", _noclipOptions.howToActivateNoclip);
+            SendHint(_noclipOptions.howToActivateNoclip);
         }
         else
         {
@@ -303,6 +309,15 @@ public class NoclipManager : MonoBehaviour
         bool backToBody = Vector3.Distance(_noclipCamera.transform.position, _realityCamera.transform.position) < distThreshold;
         bool sameRealCameraOrientation = Quaternion.Angle(_noclipCamera.transform.rotation, _realityCamera.transform.rotation) < degreesThreshold;
         return backToBody && sameRealCameraOrientation;
+    }
+
+    private void SendHint(string hintText)
+    {
+        if (_hintsAreEnabled)
+            EventManager.TriggerEvent("DisplayHint", _noclipOptions.howToActivateNoclip);
+        else
+            Debug.Log("Hint disabled: " + hintText);
+
     }
 
     private IEnumerator GetNoClipObjControllers()

--- a/Assets/Level/Prefabs/AreaManager.prefab
+++ b/Assets/Level/Prefabs/AreaManager.prefab
@@ -178,6 +178,7 @@ Transform:
   - {fileID: 4755851670936372079}
   - {fileID: 6808108631478938220}
   - {fileID: 3302489467471476068}
+  - {fileID: 6059518201548706836}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -229,6 +230,59 @@ MonoBehaviour:
   - PauseMenuUI_v2
   - SceneWithPlayer
   - GUI
+  _ambientIntensity: 0.7
+  _reflectionIntensity: 1
+  _fogStartDistance: 100
+  _fogEndDistance: 400
+  _fogColor: {r: 0, g: 0.65, b: 1, a: 1}
+  _fogMode: 1
+  _fogDensity: 3
+  _fog: 1
+--- !u!1 &8035935741461222947
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6059518201548706836}
+  - component: {fileID: 3225412207167737313}
+  m_Layer: 0
+  m_Name: NoclipHintsEnabler
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6059518201548706836
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8035935741461222947}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1832818251895023719}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &3225412207167737313
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8035935741461222947}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8af68a12c4a7487d90dbbb962040caf5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  noclipHintsEnabled: 1
 --- !u!1 &9109041096669486898
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Level/Scenes/Areas/Area_00.unity
+++ b/Assets/Level/Scenes/Areas/Area_00.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 0.032
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 1284544243}
-  m_IndirectSpecularColor: {r: 0.0005585765, g: 0.0008909935, b: 0.0044246037, a: 0.032}
+  m_IndirectSpecularColor: {r: 0.0005573185, g: 0.00088949496, b: 0.0044209897, a: 0.032}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -55366,8 +55366,8 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 189886560}
-  - {fileID: 11742405}
   - {fileID: 1138106349}
+  - {fileID: 11742405}
   m_Father: {fileID: 820070384}
   m_RootOrder: 15
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -58145,6 +58145,11 @@ PrefabInstance:
       propertyPath: _customAreaSoundtrack
       value: 
       objectReference: {fileID: 8300000, guid: 5982cad83995b5e40957c0b9700fb1ff, type: 3}
+    - target: {fileID: 3225412207167737313, guid: 653048c31db304d4c9dedd7e832c3385,
+        type: 3}
+      propertyPath: noclipHintsEnabled
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 4755851670936372076, guid: 653048c31db304d4c9dedd7e832c3385,
         type: 3}
       propertyPath: _scenesToLoad.Array.data[0]


### PR DESCRIPTION
Use the new option in AreaManager to disable/enable the hints coming from the `NoclipManager`

![image](https://user-images.githubusercontent.com/36990714/211396216-ad8a4fe7-4d5f-4208-ab99-050ee776636a.png)
